### PR TITLE
fix up notebooks and add netcdf4 to env file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - scipy
   - siphon
   - xarray
+  - netcdf4

--- a/notebooks/specialty/Observational_Data_Cross_Section.ipynb
+++ b/notebooks/specialty/Observational_Data_Cross_Section.ipynb
@@ -136,7 +136,8 @@
     "    \"\"\"\n",
     "    from pyproj import Geod\n",
     "    from scipy.interpolate import griddata\n",
-    "    \n",
+    "\n",
+    "    # Common data units\n",
     "    data_units = {'pressure': 'hPa',\n",
     "                  'height': 'meter',\n",
     "                  'temperature': 'degC',\n",
@@ -151,6 +152,10 @@
     "                  'latitude': 'degrees',\n",
     "                  'longitude': 'degrees',\n",
     "                  'elevation': 'meter',\n",
+    "                  'ice_point_temperature': 'degC',\n",
+    "                  'relative_humidity': 'percent',\n",
+    "                  'humidity_wrt_ice': 'percent',\n",
+    "                  'mixing_ratio': 'g/kg',\n",
     "                  'pw': 'millimeter'}\n",
     "    # Set up vertical grid, largest value first (high pressure nearest surface)\n",
     "    vertical_levels = np.arange(start, end-1, -step) * units(data_units['pressure'])\n",
@@ -164,7 +169,9 @@
     "    lats = []\n",
     "    lons = []\n",
     "    elev = []\n",
-    "    keys = data[stns[0]].keys()[:8]\n",
+    "    keys = ['longitude', 'latitude', 'pressure', 'height', 'temperature',\n",
+    "            'dewpoint', 'mixing_ratio', 'direction', 'speed', 'u_wind',\n",
+    "            'v_wind']\n",
     "    tmp_grid = dict.fromkeys(keys)\n",
     "\n",
     "    # Interpolate all variables for each radiosonde observation\n",
@@ -175,7 +182,7 @@
     "            if key == 'pressure':\n",
     "                lats.append(data[station].latitude[0])\n",
     "                lons.append(data[station].longitude[0])\n",
-    "                elev.append(data[station].elevation[0])\n",
+    "                elev.append(data[station].height[0])\n",
     "                tmp_grid[key][loc, :] = vertical_levels\n",
     "            else:\n",
     "                tmp_grid[key][loc, :] = vertical_interpolate(\n",
@@ -199,7 +206,7 @@
     "    pdist, ddist = np.meshgrid(vertical_levels.m, dist)\n",
     "\n",
     "    # Interpolate to 2D grid using scipy.interpolate.griddata\n",
-    "    for key in grid.keys():\n",
+    "    for key in tmp_grid.keys():\n",
     "        grid[key] = np.empty((nx, plevs)) * units(data_units[key])\n",
     "        grid[key][:] = griddata((ddist.flatten(), pdist.flatten()),\n",
     "                                tmp_grid[key][:].flatten(),\n",
@@ -298,8 +305,7 @@
     "Calculate Variables for Plotting\n",
     "--------------------------------\n",
     "\n",
-    "Use MetPy to calculate common variables for plotting a cross section,\n",
-    "specifically potential temperature and mixing ratio"
+    "Use MetPy to calculate potential temperature for plotting a cross section."
    ]
   },
   {
@@ -309,15 +315,7 @@
    "outputs": [],
    "source": [
     "potemp = mpcalc.potential_temperature(\n",
-    "    xsect['p_grid'], xsect['grid_data']['temperature'])\n",
-    "\n",
-    "relhum = mpcalc.relative_humidity_from_dewpoint(\n",
-    "    xsect['grid_data']['temperature'],\n",
-    "    xsect['grid_data']['dewpoint'])\n",
-    "\n",
-    "mixrat = mpcalc.mixing_ratio_from_relative_humidity(xsect['p_grid'],\n",
-    "                                                    xsect['grid_data']['temperature'],\n",
-    "                                                    relhum)"
+    "    xsect['p_grid'], xsect['grid_data']['temperature'])"
    ]
   },
   {
@@ -379,7 +377,8 @@
     "ax.clabel(cs, fmt='%i')\n",
     "\n",
     "# Plot smoothed mixing ratio grid (g/kg)\n",
-    "cs = ax.contour(xsect['x_grid'], xsect['p_grid'], mpcalc.smooth_gaussian(mixrat*1000, 2),\n",
+    "cs = ax.contour(xsect['x_grid'], xsect['p_grid'],\n",
+    "                mpcalc.smooth_gaussian(xsect['grid_data']['mixing_ratio'], 2),\n",
     "                range(0, 41, 2), colors='tab:green', linestyles='dotted')\n",
     "ax.clabel(cs, fmt='%i')\n",
     "\n",
@@ -406,7 +405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.14.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/synoptic/250hPa_Hemispheric_Plot.ipynb
+++ b/notebooks/synoptic/250hPa_Hemispheric_Plot.ipynb
@@ -166,8 +166,7 @@
     "\n",
     "# Add colorfilled wind speed in knots every 20 kts\n",
     "clevsped250 = np.arange(50, 200, 20)\n",
-    "cmap = plt.cm.get_cmap('BuPu')\n",
-    "cf = ax.contourf(lons, lats, smooth_wspd250, clevsped250, cmap=cmap,\n",
+    "cf = ax.contourf(lons, lats, smooth_wspd250, clevsped250, cmap=plt.cm.BuPu,\n",
     "                 extend='max', transform=datacrs)\n",
     "cbar = plt.colorbar(cf, orientation='horizontal', pad=0, aspect=50,\n",
     "                    extendrect=True)"
@@ -190,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.14.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/synoptic/Geostrophic_Wind_And_Few_More.ipynb
+++ b/notebooks/synoptic/Geostrophic_Wind_And_Few_More.ipynb
@@ -187,7 +187,6 @@
     "\n",
     "plt.contour(new_data.lon, new_data.lat,gaussian_filter(gph[0,12,:,:],1), colors = \"black\")\n",
     "# plt.contourf(new_data.lon, new_data.lat, new_data.OMEGA[0,12,:,:],levels =np.arange(-2,2,0.2),cmap = \"RdBu\", transform=dataproj,extend = \"both\" )\n",
-    "plt.colorbar (orientation = \"horizontal\", pad=0.01).ax.tick_params(labelsize=20)\n",
     "# plt.colorbar (orientation = \"horizontal\", pad=0.01).ax.tick_params(labelsize=20)\n",
     "plt.quiver (new_data.lon, new_data.lat, qx[0,12,:,:],gaussian_filter(qy[0,12,:,:],0.7), color='blue',pivot='mid', \n",
     "          scale=1e-11, scale_units='inches',\n",
@@ -214,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.14.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When I was on the MetPy cookbook site today I saw that there were a number of notebooks that were not properly executing. It appears that the environment file needs to explicitly list `netcdf4` to have the proper tools installed to read netCDF-like objects coming in through Siphon and other means. I've added that to the environment yaml file and fixed a few other errors after running through the notebooks.
